### PR TITLE
feat: filter user messages #58

### DIFF
--- a/MyProject/Main.cs
+++ b/MyProject/Main.cs
@@ -6,6 +6,7 @@ using CounterStrikeSharp.API.Modules.Commands;
 using CounterStrikeSharp.API.Modules.Cvars;
 using CounterStrikeSharp.API.Modules.Entities.Constants;
 using CounterStrikeSharp.API.Modules.Memory;
+using CounterStrikeSharp.API.Modules.UserMessages;
 using CounterStrikeSharp.API.Modules.Utils;
 using Microsoft.Extensions.Logging;
 using MyProject.Classes;
@@ -877,6 +878,78 @@ public class Main(
         }
         #endregion local methods
     }
+
+    private HookResult OnMeesagePrint(UserMessage native)
+    {
+        var filterSet = new HashSet<string>()
+        {
+            "#Player_Cash_Award_Bomb_Planted",
+            "#Player_Cash_Award_Bomb_Defused",
+            "#Player_Cash_Award_Killed_VIP",
+            "#Player_Cash_Award_Killed_Enemy",
+            "#Player_Cash_Award_Killed_Enemy_Generic",
+            "#Player_Cash_Award_Rescued_Hostage",
+            "#Player_Cash_Award_Interact_Hostage",
+            "#Player_Cash_Award_Respawn",
+            "#Player_Cash_Award_Get_Killed",
+            "#Player_Cash_Award_Kill_Teammate",
+            "#Player_Cash_Award_Damage_Hostage",
+            "#Player_Cash_Award_Kill_Hostage",
+            "#Player_Point_Award_Killed_Enemy",
+            "#Player_Point_Award_Killed_Enemy_Plural",
+            "#Player_Point_Award_Killed_Enemy_NoWeapon",
+            "#Player_Point_Award_Killed_Enemy_NoWeapon_Plural",
+            "#Player_Point_Award_Assist_Enemy",
+            "#Player_Point_Award_Assist_Enemy_Plural",
+            "#Player_Point_Award_Picked_Up_Dogtag",
+            "#Player_Point_Award_Picked_Up_Dogtag_Plural",
+            "#Player_Team_Award_Killed_Enemy",
+            "#Player_Team_Award_Killed_Enemy_Plural",
+            "#Player_Team_Award_Bonus_Weapon",
+            "#Player_Team_Award_Bonus_Weapon_Plural",
+            "#Player_Team_Award_Picked_Up_Dogtag",
+            "#Player_Team_Award_Picked_Up_Dogtag_Plural",
+            "#Player_Team_Award_Picked_Up_Dogtag_Friendly",
+            "#Player_Cash_Award_ExplainSuicide_YouGotCash",
+            "#Player_Cash_Award_ExplainSuicide_TeammateGotCash",
+            "#Player_Cash_Award_ExplainSuicide_EnemyGotCash",
+            "#Player_Cash_Award_ExplainSuicide_Spectators",
+            "#Team_Cash_Award_T_Win_Bomb",
+            "#Team_Cash_Award_Elim_Hostage",
+            "#Team_Cash_Award_Elim_Bomb",
+            "#Team_Cash_Award_Win_Time",
+            "#Team_Cash_Award_Win_Defuse_Bomb",
+            "#Team_Cash_Award_Win_Hostages_Rescue",
+            "#Team_Cash_Award_Win_Hostage_Rescue",
+            "#Team_Cash_Award_Loser_Bonus",
+            "#Team_Cash_Award_Bonus_Shorthanded",
+            "#Team_Cash_Award_Loser_Bonus_Neg",
+            "#Team_Cash_Award_Loser_Zero",
+            "#Team_Cash_Award_Rescued_Hostage",
+            "#Team_Cash_Award_Hostage_Interaction",
+            "#Team_Cash_Award_Hostage_Alive",
+            "#Team_Cash_Award_Planted_Bomb_But_Defused",
+            "#Team_Cash_Award_Survive_GuardianMode_Wave",
+            "#Team_Cash_Award_CT_VIP_Escaped",
+            "#Team_Cash_Award_T_VIP_Killed",
+            "#Team_Cash_Award_no_income",
+            "#Team_Cash_Award_no_income_suicide",
+            "#Team_Cash_Award_Generic",
+            "#Team_Cash_Award_Custom",
+            "#Cstrike_TitlesTXT_Game_teammate_attack"
+        };
+
+        int count = native.GetRepeatedFieldCount("param");
+        if (count > 0)
+        {
+            string messageId = native.ReadString("param", 0); // ["#Player_Cash_Award_Killed_Enemy", "300", "Player1"]
+
+            if (filterSet.Contains(messageId))
+                return HookResult.Stop;
+        }
+
+        return HookResult.Continue;
+    }
     #endregion hook result
 
     #region commands
@@ -1153,6 +1226,8 @@ public class Main(
 
         AddCommandListener("say", OnPlayerSayCommand);
         AddCommandListener("say_team", OnPlayerSayCommand);
+
+        HookUserMessage(124, OnMeesagePrint, HookMode.Pre);
     }
 
     private void InitialSaySoundsSync()


### PR DESCRIPTION
- Added OnMeesagePrint method to hook user message type 124
- Suppresses display/handling of specific award-related messages
- Utilizes a predefined set of message IDs for filtering
- Registers the hook during plugin initialization using CounterStrikeSharp API